### PR TITLE
Temperature Fallback Icon

### DIFF
--- a/widgets@aylur/shared/systemLevels.js
+++ b/widgets@aylur/shared/systemLevels.js
@@ -362,6 +362,7 @@ class TempLevel extends UsageLevel{
         super._init(vertical);
 
         this.icon.icon_name = 'temperature-symbolic';
+        this.icon.fallback_icon_name = 'temp-symbolic';
         this.hoverLabel.text = _('Temperature');
         this.colorSwitchValues = [ 50, 65, 80 ];
     }


### PR DESCRIPTION
With the [Papirus](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/master/Papirus/symbolic/status/temp-symbolic.svg) theme, they use `temp-symbolic` rather than `temperature-symbolic`.
This adds a fallback for that shorthand.